### PR TITLE
Zmiana aktualnej stabilnej wersji na 7.1

### DIFF
--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -6,7 +6,7 @@ isChild: true
 ## Korzystaj z ostatniej stabilnej wersji {#use_the_current_stable_version_title}
 
 Jeżeli dopiero rozpoczynasz swoją przygodę z PHP, upewnij się, że korzystasz z ostatniej stabilnej wersji (obecnie
-[PHP 7.0][php-release]). PHP jest silnie rozwijane i twórcy tego języka wciąż dodają do niego
+[PHP 7.1][php-release]). PHP jest silnie rozwijane i twórcy tego języka wciąż dodają do niego
 [nowe, przydatne funkcje](#language_highlights). Mimo tego, że konwencja nadawania kolejnych numerów wersji języka
 może sugerować, że zmiany są niewielkie, w rzeczywistości różnice między kolejnymi wersjami są _znaczące_. Na stronach
 [php.net][php-docs] dostępna jest obszerna, przetłumaczona na wiele języków dokumentacja zawierająca opis możliwości


### PR DESCRIPTION
Proponuję, aby zmienić wersję PHP na 7.1, ponieważ od 1 grudnia 2016 jest to aktualna stabilna wersja.