### PR TITLE
Add native language names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Start
 
-Witaj w repozytorium GitHub Pages dla polskiego tłumaczenia projektu _PHP: The Right Way_! 
+Witaj w repozytorium GitHub Pages dla polskiego tłumaczenia projektu _PHP: The Right Way_!
 
 * Ta strona jest projektem Jekyll.
-* Kolejne sekcje i podsekcje są plikami *.md (Markdown) w katalogu `_posts/`.
+* Kolejne sekcje i podsekcje są plikami \*.md (Markdown) w katalogu `_posts/`.
 * Podsekcje posiadają wpis `isChild: true` w nagłówku.
 * Nawigacja boczna i struktura strony jest generowana automagicznie.
 
@@ -21,7 +21,7 @@ pomóc nam promować tę inicjatywę wśród programistów PHP.
 1. Zrób forka i wprowadź swoje zmiany.
 2. Zainstaluj [Ruby](https://rvm.io/rvm/install/) oraz [Jekyll](https://github.com/mojombo/jekyll/), aby podejrzeć
 swoją pracę lokalnie.
-3. Wyślij "pull request", abyśmy mogli rozważyć wprowadzenie Twoich zmian do głównego repozytorium. 
+3. Wyślij "pull request", abyśmy mogli rozważyć wprowadzenie Twoich zmian do głównego repozytorium.
 
 ### Przyjęty styl
 
@@ -34,10 +34,28 @@ swoją pracę lokalnie.
 
 <http://www.phptherightway.com>
 
-* [Angielski](http://www.phptherightway.com)
-* [Chiński](http://wulijun.github.com/php-the-right-way)
+* [English](http://www.phptherightway.com)
+* [Deutsch](http://rwetzlmayr.github.io/php-the-right-way)
+* [Español](http://phpdevenezuela.github.io/php-the-right-way)
+* [Français](http://eilgin.github.io/php-the-right-way/)
+* [Indonesia](http://id.phptherightway.com)
+* [Italiano](http://it.phptherightway.com)
 * [Polski](http://pl.phptherightway.com)
-* [Portugalski](http://br.phptherightway.com/)
+* [Português do Brasil](http://br.phptherightway.com)
+* [Română](https://bgui.github.io/php-the-right-way/)
+* [Slovenščina](http://sl.phptherightway.com)
+* [Srpski](http://phpsrbija.github.io/php-the-right-way/)
+* [Türkçe](http://hkulekci.github.io/php-the-right-way/)
+* [български](http://bg.phptherightway.com)
+* [Русский язык](http://getjump.github.io/ru-php-the-right-way)
+* [Українська](http://iflista.github.com/php-the-right-way)
+* [العربية](https://adaroobi.github.io/php-the-right-way/)
+* [فارسى](http://novid.github.io/php-the-right-way/)
+* [ภาษาไทย](https://apzentral.github.io/php-the-right-way/)
+* [한국어판](http://modernpug.github.io/php-the-right-way)
+* [日本語](http://ja.phptherightway.com)
+* [简体中文](http://laravel-china.github.io/php-the-right-way/)
+* [繁體中文](http://laravel-taiwan.github.io/php-the-right-way)
 
 ### Tłumaczenia
 
@@ -47,7 +65,7 @@ opublikuj swoje tłumaczenie przy pomocy GitHub Pages. Twoja praca zostanie podl
 Masz możliwość uruchomienia swojego tłumaczenia w adresie GitHub, np. `[username].github.com/php-the-right-way`
 lub w naszej subdomenie, np. `ru.phptherightway.com`. Jeżeli chcesz skorzystać z subdomeny, wpisz jej nazwę w pliku
 `CNAME`, który znajduje się w głównym katalogu projektu. W przeciwnym wypadku usuń ten plik całkowicie, gdyż w
-przeciwnym razie Twoje strona nie opublikuje się. 
+przeciwnym razie Twoje strona nie opublikuje się.
 
 Po zakończeniu swojej pracy dodaj zgłoszenie w Issue Trackerze oryginalnego repozytorium, abyśmy mogli podlinkować
 Twoją pracę.

--- a/_includes/welcome.md
+++ b/_includes/welcome.md
@@ -3,31 +3,34 @@
 W Sieci można znaleźć wiele publikacji na temat PHP. Niestety, wiele z nich jest nieaktualnych, niekompletnych lub nie
 odnosi się do aktualnych dostępnych wersji. Wprowadza to wszechobecny zamęt i prowadzi nowych fanów tego języka na
 przysłowiowe manowce. Tak dalej być nie może. _PHP: The Right Way_ jest przystępnym zbiorem najlepszych praktyk i
-standardów kodowania, a także linków do sprawdzonych i solidnych tutoriali pałętających się w czeluściach Internetu. 
+standardów kodowania, a także linków do sprawdzonych i solidnych tutoriali pałętających się w czeluściach Internetu.
 
 ## Tłumaczenia
 
 _PHP: The Right Way_ jest (lub niebawem będzie) przetłumaczony na wiele języków:
 
-* [Angielski](http://www.phptherightway.com)
-* [Bułgarski](http://bg.phptherightway.com/)
-* [Chiński (uproszczony)](http://wulijun.github.com/php-the-right-way)
-* [Chiński (tradycyjny)](https://laravel-taiwan.github.io/php-the-right-way/)
-* [Francuski](https://eilgin.github.io/php-the-right-way/)
-* [Hiszpański](http://es.phptherightway.com)
-* [Indonezyjski](http://id.phptherightway.com/)
-* [Japoński](http://ja.phptherightway.com)
-* [Koreański](https://wafe.github.io/php-the-right-way/)
-* [Niemiecki](https://rwetzlmayr.github.io/php-the-right-way/)
+* [English](http://www.phptherightway.com)
+* [Deutsch](http://rwetzlmayr.github.io/php-the-right-way)
+* [Español](http://phpdevenezuela.github.io/php-the-right-way)
+* [Français](http://eilgin.github.io/php-the-right-way/)
+* [Indonesia](http://id.phptherightway.com)
+* [Italiano](http://it.phptherightway.com)
 * [Polski](http://pl.phptherightway.com)
-* [Portugalski](http://br.phptherightway.com/)
-* [Rosyjski](https://getjump.github.io/ru-php-the-right-way/)
-* [Rumuński](https://bgui.github.io/php-the-right-way/)
-* [Słoweński](http://sl.phptherightway.com/)
-* [Tajski](https://apzentral.github.io/php-the-right-way/)
-* [Turecki](http://kulekci.net/php-the-right-way/)
-* [Ukraiński](http://iflista.github.com/php-the-right-way/)
-* [Włoski](http://it.phptherightway.com/)
+* [Português do Brasil](http://br.phptherightway.com)
+* [Română](https://bgui.github.io/php-the-right-way/)
+* [Slovenščina](http://sl.phptherightway.com)
+* [Srpski](http://phpsrbija.github.io/php-the-right-way/)
+* [Türkçe](http://hkulekci.github.io/php-the-right-way/)
+* [български](http://bg.phptherightway.com)
+* [Русский язык](http://getjump.github.io/ru-php-the-right-way)
+* [Українська](http://iflista.github.com/php-the-right-way)
+* [العربية](https://adaroobi.github.io/php-the-right-way/)
+* [فارسى](http://novid.github.io/php-the-right-way/)
+* [ภาษาไทย](https://apzentral.github.io/php-the-right-way/)
+* [한국어판](http://modernpug.github.io/php-the-right-way)
+* [日本語](http://ja.phptherightway.com)
+* [简体中文](http://laravel-china.github.io/php-the-right-way/)
+* [繁體中文](http://laravel-taiwan.github.io/php-the-right-way)
 
 ## Uwaga
 
@@ -45,7 +48,7 @@ rozwoju, bądź masz uwagi do bieżącego tłumaczenia, przeczytaj poniższy aka
 Jeżeli chciałbyś/chciałabyś mieć wpływ na zawartość tego dokumentu lub po prostu chcesz powiedzieć światu o tej
 inicjatywie - zapraszamy!
 
-[Strona projektu w serwisie GitHub][1] 
+[Strona projektu w serwisie GitHub][1]
 
 ## Podziel się dobrą informacją!
 


### PR DESCRIPTION
Hello, this patch includes the native language names for all translations in the `README.md` and `welcome.md` files. This is probably more logical from the native speaker's point of view. Sorted alphabetically and with English being on top.

Thank you for considering merging it. In case you want some adjustments for your translations, let me know.